### PR TITLE
Fix varargs Behavior in asprintf_portable()

### DIFF
--- a/format.c
+++ b/format.c
@@ -128,7 +128,10 @@ static int asprintf_portable(char **str, const char *fmt, ...) {
 	va_list ap;
 
 	va_start(ap, fmt);
-	len = vsnprintf(*str, 0, fmt, ap);
+	len = vsnprintf(NULL, 0, fmt, ap);
+	va_end(ap);
+
+	va_start(ap, fmt);
 	*str = malloc(len+1);
 	len = (*str == NULL) ? -1 : vsnprintf(*str, len+1, fmt, ap);
 	va_end(ap);


### PR DESCRIPTION
Otherwise produces a segfault for me. Compiler: `gcc (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609`

`vsnprintf()` makes the `va_list` not usable anymore, so it has to be restarted.